### PR TITLE
fix pagination: order by user + next page crashed with php8

### DIFF
--- a/Controller/TicketController.php
+++ b/Controller/TicketController.php
@@ -85,7 +85,7 @@ final class TicketController extends AbstractController
 
         $pagination = $this->pagination->paginate(
             $query->getQuery(),
-            $request->query->get('page', 1)/*page number*/,
+            intval($request->query->get('page', 1))/*page number*/,
             10/*limit per page*/
         );
 

--- a/Resources/views/Ticket/index.html.twig
+++ b/Resources/views/Ticket/index.html.twig
@@ -41,7 +41,7 @@
         <tr>
             <th class="col-xs-1">{{ knp_pagination_sortable(pagination, 'HEADING_TICKET'|trans({}, translationDomain), 't.id') }}</th>
             <th{% if pagination.isSorted('t.subject') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_SUBJECT'|trans({}, translationDomain), 't.subject') }}</th>
-            <th{% if pagination.isSorted('t.userCreated') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_AUTHOR'|trans({}, translationDomain), 't.userCreated') }}</th>
+            <th{% if pagination.isSorted('u.email') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_AUTHOR'|trans({}, translationDomain), 'u.email') }}</th>
             <th{% if pagination.isSorted('t.status') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_STATUS'|trans({}, translationDomain), 't.status') }}</th>
             <th{% if pagination.isSorted('t.priority') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_PRIORITY'|trans({}, translationDomain), 't.priority') }}</th>
             <th{% if pagination.isSorted('t.modified') %} class="sorted"{% endif %}>{{ knp_pagination_sortable(pagination, 'HEADING_MODIFIED'|trans({}, translationDomain), 't.lastMessage') }}</th>


### PR DESCRIPTION
Hi,

I found 2 minor bugs in ticket list pagination:
- user sort is not working, in fact the only field that will 100% be present seems to be email
- had to cas page number to int or it crashed when using php8

Regards.